### PR TITLE
noaa-intel-prototype: fix spack env loads

### DIFF
--- a/apps/Dockerfile-fail-i2024
+++ b/apps/Dockerfile-fail-i2024
@@ -1,4 +1,4 @@
-FROM ecpe4s/noaa-intel-prototype:2024.03.22 as builder
+FROM ecpe4s/noaa-intel-prototype:2024.03.27 as builder
 LABEL maintainer "Tom Robinson"
 RUN mkdir -p /opt/spack-environment
 # Copy the spack.yaml
@@ -14,4 +14,4 @@ RUN . /spack/share/spack/setup-env.sh \
  && cd /opt/spack-environment  \
  && spack env activate --sh -d . >> /etc/profile.d/z10_spack_environment.sh \
  && spack env activate . \ 
- && spack env loads 
+ && spack env loads -m lmod

--- a/apps/Dockerfile-fail-i2024
+++ b/apps/Dockerfile-fail-i2024
@@ -15,25 +15,3 @@ RUN . /spack/share/spack/setup-env.sh \
  && spack env activate --sh -d . >> /etc/profile.d/z10_spack_environment.sh \
  && spack env activate . \ 
  && spack env loads 
-# && sed -i 's/%intel@2021.10.0.*//' /opt/spack-environment/loads \
-# && sed -i 's/#/spack load/' /opt/spack-environment/loads \
-# && sed -i 's/module.*//' /opt/spack-environment/loads \
-# && cat /opt/spack-environment/loads >> /etc/bash.bashrc
-# Build the vortex tracker
-RUN . /spack/share/spack/setup-env.sh \
- && sed -i 's/module/spack/' /opt/spack-environment/loads \
- && . /opt/spack-environment/loads \
- && mkdir -p /apps && cd /apps \
- && git clone https://github.com/NOAA-GFDL/GFDL-VortexTracker.git && cd /apps/GFDL-VortexTracker/src \
- && cmake .. -DCMAKE_Fortran_COMPILER="ifort" -DCMAKE_C_COMPILER="icc" \
- && make -j 8 VERBOSE=1 \
- && make install
-# Create the run script
-RUN mkdir -p /apps \
- && touch /apps/run \
- && chmod 777 /apps/run \
- && echo '#/bin/bash' >> /apps/run \
- && echo '. /spack/share/spack/setup-env.sh' >> /apps/run \
- && echo '. /opt/spack-environment/loads' >> /apps/run \
- && echo '${1}'  >> /apps/run
-

--- a/apps/Dockerfile-fail-i2024
+++ b/apps/Dockerfile-fail-i2024
@@ -1,0 +1,39 @@
+FROM ecpe4s/noaa-intel-prototype:2024.03.22 as builder
+LABEL maintainer "Tom Robinson"
+RUN mkdir -p /opt/spack-environment
+# Copy the spack.yaml
+COPY spack_intel2024_gfdl_model.yaml /opt/spack-environment/spack.yaml
+# Set up the spack environment with the spack.yaml
+RUN mkdir -p /opt/spack-environment \
+ && cd /opt/spack-environment \
+ && . /spack/share/spack/setup-env.sh \
+ && spack env activate .\
+ && spack install --fail-fast
+# Create the spack loads for the packages on startup
+RUN . /spack/share/spack/setup-env.sh \
+ && cd /opt/spack-environment  \
+ && spack env activate --sh -d . >> /etc/profile.d/z10_spack_environment.sh \
+ && spack env activate . \ 
+ && spack env loads 
+# && sed -i 's/%intel@2021.10.0.*//' /opt/spack-environment/loads \
+# && sed -i 's/#/spack load/' /opt/spack-environment/loads \
+# && sed -i 's/module.*//' /opt/spack-environment/loads \
+# && cat /opt/spack-environment/loads >> /etc/bash.bashrc
+# Build the vortex tracker
+RUN . /spack/share/spack/setup-env.sh \
+ && sed -i 's/module/spack/' /opt/spack-environment/loads \
+ && . /opt/spack-environment/loads \
+ && mkdir -p /apps && cd /apps \
+ && git clone https://github.com/NOAA-GFDL/GFDL-VortexTracker.git && cd /apps/GFDL-VortexTracker/src \
+ && cmake .. -DCMAKE_Fortran_COMPILER="ifort" -DCMAKE_C_COMPILER="icc" \
+ && make -j 8 VERBOSE=1 \
+ && make install
+# Create the run script
+RUN mkdir -p /apps \
+ && touch /apps/run \
+ && chmod 777 /apps/run \
+ && echo '#/bin/bash' >> /apps/run \
+ && echo '. /spack/share/spack/setup-env.sh' >> /apps/run \
+ && echo '. /opt/spack-environment/loads' >> /apps/run \
+ && echo '${1}'  >> /apps/run
+

--- a/apps/spack_intel2024_gfdl_model.yaml
+++ b/apps/spack_intel2024_gfdl_model.yaml
@@ -1,0 +1,53 @@
+# base image = ecpe4s/ubuntu20.04-oneapi-x86_64:22.02
+# # spack commit = 76b7095445264fb02b53616695fc226266f76695
+# # mirror = https://cache.e4s.io/noaa
+ 
+spack:
+#  mirrors:
+#    E4S: https://cache.e4s.io/noaa
+#
+  packages:
+    all:
+      compiler: [intel@2021.10.0]
+      target: [x86_64]
+      providers:
+        mpi: [intel-oneapi-mpi]
+    intel-oneapi-mpi:
+      buildable: false
+      externals:
+      - spec: intel-oneapi-mpi@2021.10.0
+        prefix: /opt/intel/oneapi
+        modules:
+        - mpi/2021.10.0
+
+  compilers:
+  - compiler:
+      spec: intel@2021.10.0
+      paths:
+        cc: /opt/intel/oneapi/compiler/2023.2.1/linux/bin/intel64/icc
+        cxx: /opt/intel/oneapi/compiler/2023.2.1/linux/bin/intel64/icpc
+        f77: /opt/intel/oneapi/compiler/2023.2.1/linux/bin/intel64/ifort
+        fc: /opt/intel/oneapi/compiler/2023.2.1/linux/bin/intel64/ifort
+      flags: {}
+      operating_system: ubuntu20.04
+      target: x86_64
+      modules:
+      - compiler/2023.2.1
+      environment: {}
+      extra_rpaths:
+      - /opt/intel/oneapi/compiler/2023.2.1/linux/compiler/lib/intel64_lin
+
+  view: false
+  specs:
+  - automake@1.16.5
+  - bacio@2.4.1
+  - libjpeg-turbo@3.0.0
+  - libpng@1.6.37
+  - libyaml@0.2.5
+  - netcdf-c@4.9.2
+  - netcdf-fortran@4.6.0
+  - jasper
+  - g2
+  - sp@2.5.0
+  - w3emc@2.10.0
+  - w3nco@2.4.1


### PR DESCRIPTION
Use latest image and explicitly specify `spack env loads -m lmod`

@thomas-robinson 